### PR TITLE
Added repo_name file

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,0 +1,1 @@
+steam-overlay


### PR DESCRIPTION
I added  a repo_name file so that portage stops complaining that it's missing
