### PR TITLE
Patching steam to avoid missing xterm dep.

### DIFF
--- a/games-util/steam-installer/files/use-default-terminal.patch
+++ b/games-util/steam-installer/files/use-default-terminal.patch
@@ -1,0 +1,20 @@
+123--- usr/bin/steam.orig	2012-12-03 10:24:01.260300027 +0400
++++ usr/bin/steam	2012-12-03 10:24:45.379749695 +0400
+@@ -35,7 +35,7 @@
+ 		# Save the prompt in a temporary file because it can have newlines in it
+ 		tmpfile=`mktemp || echo "/tmp/steam_message.txt"`
+ 		echo -e "$*" >$tmpfile
+-		xterm -T "$title" -e "cat $tmpfile; echo -n 'Press enter to continue: '; read input"
++		${TERM} -T "$title" -e "cat $tmpfile; echo -n 'Press enter to continue: '; read input"
+ 		rm -f $tmpfile
+ 	fi
+ }
+@@ -65,7 +65,7 @@
+ 	fi
+ 
+ 	# Fall back to sudo in a terminal
+-	xterm -e sudo -p "$prompt
++	${TERM} -e sudo -p "$prompt
+ [sudo] password for user: " $*
+ }
+ 

--- a/games-util/steam-installer/steam-installer-9999.ebuild
+++ b/games-util/steam-installer/steam-installer-9999.ebuild
@@ -43,6 +43,7 @@ src_prepare() {
 	sed -r -i "s/^(Actions=.*)/\1;/" usr/share/applications/steam.desktop
 
 	epatch "${FILESDIR}/remove-ubuntu-specifics.patch"
+	epatch "${FILESDIR}/use-default-terminal.patch"
 }
 
 src_install() {


### PR DESCRIPTION
So steam wants xterm for some strange stuff. 

xterm depend for me will be 3 additional packages I don't need, so it's a deal:
- add xterm to dep
- or patch steam to exchange xterm to ${TERM}

according it's Gentoo and we have ${TERM} as xterm by default and my personal feelings about it I desired to patch it.

This patch is really up to you. But if you will reject it then you must add xterm to RDEPEND though.
