### PR TITLE
media-libs/libsdl: fix DOCS variable to reflect upstream rename of some files

### DIFF
--- a/media-libs/libsdl/libsdl-2.0.0_pre9999.ebuild
+++ b/media-libs/libsdl/libsdl-2.0.0_pre9999.ebuild
@@ -68,7 +68,7 @@ DEPEND="${RDEPEND}
 	xscreensaver? ( x11-proto/scrnsaverproto )
 "
 
-DOCS=( BUGS CREDITS README README.HG README-SDL.txt TODO WhatsNew )
+DOCS=( BUGS.txt CREDITS.txt README.txt README-hg.txt README-SDL.txt TODO.txt WhatsNew.txt )
 
 src_configure() {
 	mycmakeargs=(


### PR DESCRIPTION
without this fix, ebuild libsdl-2.0.0_pre9999.ebuild clean merge fails with:

!!! dodoc: BUGS does not exist
- ERROR: media-libs/libsdl-2.0.0_pre9999 failed (install phase):
-   dodoc failed
  *
- If you need support, post the output of `emerge --info '=media-libs/libsdl-2.0.0_pre9999'`,
- the complete build log and the output of `emerge -pqv '=media-libs/libsdl-2.0.0_pre9999'`.
- This ebuild is from an overlay named 'steam-overlay': '/home/pinkbyte/dev/steam-overlay/'
- The complete build log is located at '/home/tmp/portage/media-libs/libsdl-2.0.0_pre9999/temp/build.log'.
- The ebuild environment file is located at '/home/tmp/portage/media-libs/libsdl-2.0.0_pre9999/temp/environment'.
- Working directory: '/home/tmp/portage/media-libs/libsdl-2.0.0_pre9999/work/libsdl-2.0.0_pre9999'
- S: '/home/tmp/portage/media-libs/libsdl-2.0.0_pre9999/work/libsdl-2.0.0_pre9999'
- QA Notice: file does not exist:
  *
-      dodoc: BUGS does not exist

Note that BUGS is not only file, that was renamed, details is in commit...
