### PR TITLE
add new file with updated steam client dependencies

### DIFF
--- a/games-util/steam-client-meta/steam-client-meta-0-r20131107.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20131107.ebuild
@@ -20,6 +20,7 @@ IUSE="flash trayicon video_cards_intel"
 
 RDEPEND="
 		virtual/opengl
+		net-misc/curl
 
 		media-fonts/font-mutt-misc
 		|| ( media-fonts/font-bitstream-100dpi media-fonts/font-adobe-100dpi )


### PR DESCRIPTION
Hi, 

I've created a new version of steam-client-meta with updated dependencies. All of this changes were tested on my x86 system (i can't really test on a amd64 system because installing steam without steamruntime would install emul packages which would include most dependencies anyway - even those not needed).
Dependencies which i'd removed were also removed on my test-system to be sure they are really not needed. Following is the list of binaries/libraries which i checked for dependencies.

```
chromehtml.so
crashhandler.so
filesystem_stdio.so
friendsui.so
gameoverlayrenderer.so
gameoverlayui.so
serverbrowser.so
steam
steamclient.so
steamerrorreporter
steamservice.so
steamui.so
vgui2_s.so
libcef.so
libaudio.so
libmiles.so
liboverride.so
libSDL2-2.0.so.0
libsteam.so
libtier0_s.so
libvstdlib_s.so
libffmpegsumo.so
```

Please let me know if i forgot files.

Following changes include:

_remove libsdl2 dependency (x86/amd64)_:
It's not needed to install libsdl2 for steam. In fact, steam comes with his own libSDL2 library which would be used no matter if steamruntime is set or not. The library is even not included in the steamruntime directory but directly in the steam root directory under ubuntu12_32.
Actually we could replace steam's libSDL2 with our own libSDL2, but that must be done by the ebuild. Further more i wouldn't do that since we don't know if valve patches it's libSDL2. Another reason not replacing libSDL2 with our own is that we also couldn't support steamruntime anymore since we replaced a library which isn't included with steamruntime.

_remove of libtheora/libvorbis/pixman/libogg/libjpeg-turbo_:
As mentioned before, steam starts and works without them flawless.

_net-misc/curl move_:
Actually curl is also not needed for steam, however i've moved it to the arch independent part, cause it might be needed for the scripts. 

_added networkmanager/dbus-glib/libusb/libxinerama/libSM/libICE_:
networkmanager provides libnm-glib.so.4 and libnm-util.so.2 which is needed by steamclient.so
I was wondering this dependencies was missing. On amd64 it's provided by steam-runtime-bin (since emul-package don't provide them). 
dbus-glib provides libdbus-glib-1.so.2 which is needed by steamclient.so
libusb provides libusb-1.0.so.0 which is needed by steamclient.so
libxinerama provides libXinerama.so.1 which is needed by vgui2_s.so
libSM provides libSM.so.6 which is needed by vgui2_s.so
libICE provides libICE.so.6 which is needed by vgui2_s.so

I've also updated the dependencies when using multilib x11 libs accordingly.

Any comments/suggestions?
