### PR TITLE
add multilib flag for nvidia-cg-toolkit on amd64

### DIFF
--- a/games-util/steam-games-meta/steam-games-meta-0-r20131107.ebuild
+++ b/games-util/steam-games-meta/steam-games-meta-0-r20131107.ebuild
@@ -89,7 +89,7 @@ RDEPEND="
 						x11-libs/libXxf86vm
 						)
 					amd64? (
-						>=media-gfx/nvidia-cg-toolkit-3.1.0013
+						>=media-gfx/nvidia-cg-toolkit-3.1.0013[multilib]
 						media-libs/libogg[abi_x86_32]
 						media-libs/libvorbis[abi_x86_32] 
 						x11-libs/libXxf86vm[abi_x86_32]
@@ -100,7 +100,7 @@ RDEPEND="
 				dev-util/adobe-air-runtime
 			)
 		steamgames_shatter? (
-				amd64? ( >=media-gfx/nvidia-cg-toolkit-3.1.0013 )
+				amd64? ( >=media-gfx/nvidia-cg-toolkit-3.1.0013[multilib] )
 				x86? ( media-gfx/nvidia-cg-toolkit )
 			)
 		"


### PR DESCRIPTION
Hi,

Small changes which adds the multilib flag for nvidia-cg-toolkit on amd64.

Further more i suggest removing following:

```
        steamgames_source_engine? (
                video_cards_fglrx? ( >=x11-drivers/ati-drivers-12.8 )
            )
```

There are no such old ati-drivers anymore in main-tree. The oldest one is 13.1, thus this dependency is rather useless.

Regards,
Michael
