### PR TITLE
loosen nvidia-drivers restriction

### DIFF
--- a/games-util/steam-client-meta/steam-client-meta-0-r20140616.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20140616.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 			)
 
 		!steamruntime? (
-			video_cards_nvidia? ( <=x11-drivers/nvidia-drivers-331.79 )
+			video_cards_nvidia? ( <x11-drivers/nvidia-drivers-332 )
 
 			amd64? (
 				>=sys-devel/gcc-4.6.0[multilib]


### PR DESCRIPTION
This line no longer reflects what is in portage, generalize it to allow all nvidia-drivers-331.xx varients.
