### PR TITLE
Drop libSDL useflag dependency for the client.

### DIFF
--- a/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
@@ -54,7 +54,6 @@ RDEPEND="
 			amd64? (
 				>=sys-devel/gcc-4.6.0[multilib]
 				>=sys-libs/glibc-2.15[multilib]
-				media-libs/libsdl2[abi_x86_32,alsa,dbus,gles,opengl,pulseaudio,udev,X]
 				>=app-emulation/steam-runtime-bin-20131109
 				=sys-fs/steam-runtime-udev-175-r2[abi_x86_32,gudev]
 


### PR DESCRIPTION
Technically not needed for the steam client due to aggressive enforcement of the bundled libSDL2-2.0.so in ~/.local/share/Steam/ubuntu12_32/. An appropreate line should be added in games-util/steam-games-meta if we have incomplete coverage from this change.
