### PR TITLE
Specify slot for libgcrypt

### DIFF
--- a/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
@@ -61,7 +61,7 @@ RDEPEND="
 					>=app-emulation/emul-linux-x86-baselibs-20121202
 					(
 						dev-libs/dbus-glib[abi_x86_32]
-						dev-libs/libgcrypt[abi_x86_32]
+						dev-libs/libgcrypt:11[abi_x86_32]
 						dev-libs/nspr[abi_x86_32]
 						dev-libs/nss[abi_x86_32]
 						net-misc/curl[abi_x86_32]
@@ -113,7 +113,7 @@ RDEPEND="
 			x86? (
 				dev-libs/glib:2
 				dev-libs/dbus-glib
-				dev-libs/libgcrypt
+				dev-libs/libgcrypt:11
 				virtual/libusb
 				dev-libs/nspr
 				dev-libs/nss


### PR DESCRIPTION
now that emul-linux-x86-\* is not requred when using abi_x86_32, it revealed that steamwebhelper is linked against libgcrypt.so.11. As long as we have at least one libgcrypt.so version, the rest of the occurances should be sane.
