### PR TITLE
add missing USE description

### DIFF
--- a/games-util/steam-client-meta/metadata.xml
+++ b/games-util/steam-client-meta/metadata.xml
@@ -17,6 +17,6 @@
 		<flag name='trayicon'>Enable system tray icon with libappindicator</flag>
 		<flag name='steamfonts'>Use official fonts from Valve's steam client</flag>
 		<flag name='steamruntime'>Use the official steam runtime libraries</flag>
-		<flag name='streaming'>Enable support for steam broadcasts</flag>
+		<flag name='streaming'>Enable support for steam in-home streaming</flag>
 	</use>
 </pkgmetadata>

--- a/games-util/steam-client-meta/metadata.xml
+++ b/games-util/steam-client-meta/metadata.xml
@@ -15,6 +15,8 @@
 	<use>
 		<flag name='flash'>Pull in www-plugins/adobe-flash for the internal browser</flag>
 		<flag name='trayicon'>Enable system tray icon with libappindicator</flag>
+		<flag name='steamfonts'>Use official fonts from Valve's steam client</flag>
 		<flag name='steamruntime'>Use the official steam runtime libraries</flag>
+		<flag name='streaming'>Enable support for steam broadcasts</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Hi,

I saw the metadata.xml has missing USE description for steam-client-meta. I've added them but i'm not sure about the streaming flag. Please check if my description is correct :)

regards
mmike