### PR TITLE
Various client-meta and launcher fixes

### DIFF
--- a/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
@@ -16,7 +16,7 @@ LICENSE="metapackage"
 
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="flash steamfonts +steamruntime streaming trayicon video_cards_intel video_cards_nvidia"
+IUSE="flash steamfonts +steamruntime trayicon video_cards_intel video_cards_nvidia"
 
 RDEPEND="
 		media-fonts/font-mutt-misc
@@ -25,11 +25,6 @@ RDEPEND="
 		trayicon? ( sys-apps/dbus )
 
 		steamfonts? ( media-fonts/steamfonts )
-
-		streaming? (
-				amd64? ( x11-libs/libva[abi_x86_32] )
-				x86? ( x11-libs/libva )
-			)
 
 		amd64? (
 			!x11-misc/virtualgl[-abi_x86_32]

--- a/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
+++ b/games-util/steam-client-meta/steam-client-meta-0-r20141204.ebuild
@@ -62,7 +62,7 @@ RDEPEND="
 					>=app-emulation/emul-linux-x86-baselibs-20121202
 					(
 						dev-libs/dbus-glib[abi_x86_32]
-						dev-libs/libgcrypt:11[abi_x86_32]
+						dev-libs/libgcrypt:0/11[abi_x86_32]
 						dev-libs/nspr[abi_x86_32]
 						dev-libs/nss[abi_x86_32]
 						net-misc/curl[abi_x86_32]

--- a/games-util/steam-launcher/files/1.0.0.49-no-steam_runtime.patch
+++ b/games-util/steam-launcher/files/1.0.0.49-no-steam_runtime.patch
@@ -1,0 +1,10 @@
+--- a/steam	2015-02-02 21:04:17.715311537 -0800
++++ b/steam	2015-02-02 21:02:01.770710316 -0800
+@@ -16,6 +16,7 @@
+ 
+ # Set up domain for script localization
+ export TEXTDOMAIN=steam
++if [ -z "$STEAM_RUNTIME" ]; then export STEAM_RUNTIME=0; fi
+ 
+ function show_message()
+ {

--- a/games-util/steam-launcher/steam-launcher-1.0.0.49-r2.ebuild
+++ b/games-util/steam-launcher/steam-launcher-1.0.0.49-r2.ebuild
@@ -61,7 +61,7 @@ src_prepare() {
 
 	if ! use steamruntime; then
 		# use system libraries if user has not set the variable otherwise
-		sed -i -r "s/(export TEXTDOMAIN=steam)/\1\nif \[ -z \"\$STEAM_RUNTIME\" \]; then export STEAM_RUNTIME=0; fi/" steam || die
+		epatch "${FILESDIR}/${PV}-no-steam_runtime.patch"
 		# use violent force to load the system's SDL library
 		#sed -i '/export STEAM_RUNTIME=0; fi/a if \[ \"$STEAM_RUNTIME\" == "0" \]; then export LD_PRELOAD="/usr/lib32/libSDL2-2.0.so.0"; fi' steam || die
 	fi


### PR DESCRIPTION
- Fix incorrect slot dependency on `dev-libs/libgcrypt`
- Drop unnecessary `streaming` USE flag
- Use patch to disable `STEAM_RUNTIME` instead of sed hack