### PR TITLE
unwritten tales also needs libjpeg.so.8

### DIFF
--- a/games-util/steam-games-meta/steam-games-meta-0-r20141109.ebuild
+++ b/games-util/steam-games-meta/steam-games-meta-0-r20141109.ebuild
@@ -120,8 +120,14 @@ RDEPEND="
 				)
 			)
 		steamgames_unwritten_tales? (
-				x86? ( media-libs/jasper )
-				amd64? ( >=media-libs/jasper-1.900.1-r6[abi_x86_32] )
+				x86? (
+					media-libs/jasper
+					media-libs/jpeg:8
+				)
+				amd64? (
+					>=media-libs/jasper-1.900.1-r6[abi_x86_32]
+					media-libs/jpeg:8[abi_x86_32]
+				)
 			)
 		steamgames_witcher2? (
 				!steamruntime? ( media-libs/libsdl2[haptic] )


### PR DESCRIPTION
I found this while starting it without steam runtime

./bin/32/kAGE: error while loading shared libraries: libjpeg.so.8: cannot open shared object file: No such file or directory

I don't know if any other package provides this, but media-libs/jpeg:8 does