### PR TITLE
Update steam-overlay.conf

### DIFF
--- a/steam-overlay.conf
+++ b/steam-overlay.conf
@@ -3,3 +3,4 @@ location = /usr/local/steam-overlay/
 sync-type = git
 sync-uri = https://github.com/anyc/steam-overlay/
 auto-sync = Yes
+masters = gentoo


### PR DESCRIPTION
Emerge was complaining. This fixes the issue.

    !!! Repository 'steam-overlay' is missing masters attribute in '/usr/local/steam-overlay/metadata/layout.conf'
    !!! Set 'masters = gentoo' in this file for future compatibility