### PR TITLE
Add support for user patches (/etc/portage/patches) to steam-launcher

### DIFF
--- a/games-util/steam-launcher/steam-launcher-1.0.0.50.ebuild
+++ b/games-util/steam-launcher/steam-launcher-1.0.0.50.ebuild
@@ -54,6 +54,7 @@ S=${WORKDIR}/steam/
 src_prepare() {
 	epatch "${FILESDIR}"/steam-fix-ld-library-path.patch
 	epatch "${FILESDIR}"/steam-fix-joystick-detection.patch
+	epatch_user
 
 	if ! use steamruntime; then
 		# use system libraries if user has not set the variable otherwise and add dirty hack for unbound LD_LIBRARY_PATH if it is not set

--- a/games-util/steam-launcher/steam-launcher-1.0.0.51-r1.ebuild
+++ b/games-util/steam-launcher/steam-launcher-1.0.0.51-r1.ebuild
@@ -68,6 +68,7 @@ pkg_setup() {
 src_prepare() {
 	epatch "${FILESDIR}"/steam-fix-ld-library-path.patch
 	epatch "${FILESDIR}"/steam-fix-joystick-detection.patch
+	epatch_user
 
 	sed -i -e 's:TAG+="uaccess":TAG+="uaccess", TAG+="udev-acl":g' lib/udev/rules.d/99-steam-controller-perms.rules || die
 


### PR DESCRIPTION
This pull request adds support for /etc/portage/patches to the steam-launcher ebuild. This is useful to set some environment variables for steam.

Example patch: https://gist.github.com/flyser/ad647c9bc6c5a3462c3512d2ec6a9005