### PR TITLE
steam-overlay.conf:  location and sync-uri

### DIFF
--- a/steam-overlay.conf
+++ b/steam-overlay.conf
@@ -1,5 +1,10 @@
 [steam-overlay]
-location = /usr/local/steam-overlay/
+
+# Gentoo overlay for Valve's Steam client and Steam-based games.
+# Maintainer: anyc (https://github.com/anyc)
+
+location = /usr/local/portage/steam-overlay
 sync-type = git
-sync-uri = https://github.com/anyc/steam-overlay/
+sync-uri = https://github.com/anyc/steam-overlay.git
+priority = 50
 auto-sync = Yes


### PR DESCRIPTION
Recommend location to be a subdirectory of `/usr/local/portage/`.
Added priority.
Changed `sync-uri` to git recommendation.
Added Maintainer comments.