### PR TITLE
Use etc/portage for esteam set

### DIFF
--- a/games-util/esteam/esteam-0.20161113-r1.ebuild
+++ b/games-util/esteam/esteam-0.20161113-r1.ebuild
@@ -22,9 +22,6 @@ S="${WORKDIR}"
 src_install() {
 	newbin $(prefixify_ro "${FILESDIR}"/script.bash) ${PN}
 
-	insinto /usr/share/portage/config/sets
-	newins $(prefixify_ro "${FILESDIR}"/set.conf) ${PN}.conf
-
 	insinto /usr/share/${PN}
 	doins "${FILESDIR}"/database.bash
 

--- a/games-util/esteam/files/script.bash
+++ b/games-util/esteam/files/script.bash
@@ -283,7 +283,7 @@ for ATOM in "${!ATOMS64[@]}" "${!ATOMS32[@]}"; do
 done
 
 unset CONTENTS
-SET="@GENTOO_PORTAGE_EPREFIX@/var/lib/portage/esteam"
+SET="@GENTOO_PORTAGE_EPREFIX@/etc/portage/sets/esteam"
 
 unset IFS
 for ATOM in "${!ATOMS[@]}"; do
@@ -309,6 +309,9 @@ done
 
 echo
 einfo "Writing Portage set to ${SET} ..."
+if [[ ! -d /etc/portage/sets ]]; then
+	exec ${SUDO} mkdir -p /etc/portage/sets
+fi
 echo -n "${CONTENTS}" | sort | ${SUDO} tee "${SET}" >/dev/null
 
 einfo "Executing emerge -an${@+ }${@} @esteam ..."

--- a/games-util/esteam/files/set.conf
+++ b/games-util/esteam/files/set.conf
@@ -1,4 +1,0 @@
-[esteam]
-class = portage.sets.files.StaticFileSet
-filename = @GENTOO_PORTAGE_EPREFIX@/var/lib/portage/esteam
-world-candidate = true


### PR DESCRIPTION
esteam set should be in /etc/portage like any other user set. Avoids having to install specific Portage configuration. Could be extended to use e.g. /etc/paludis instead of /etc/portage for other package managers.