### PR TITLE
games-util/esteam: Add Mad Max to UNBUNDLEABLES

### DIFF
--- a/games-util/esteam/files/database.bash
+++ b/games-util/esteam/files/database.bash
@@ -276,6 +276,7 @@ UNBUNDLEABLES=(
 	"Altitude"
 	"Anodyne"
 	"Dwarfs - F2P"
+	"Mad Max"
 	"Revenge of the Titans"
 	"Sid Meier's Civilization V"
 	"Titan Attacks"


### PR DESCRIPTION
Eliminates the bundled `libcurl.so.4` with heavy dependency chain.  No apparent problems so far.