### PR TITLE
Add missing slash

### DIFF
--- a/games-util/esteam/esteam-0.20180929.ebuild
+++ b/games-util/esteam/esteam-0.20180929.ebuild
@@ -26,7 +26,7 @@ src_install() {
 
 	if ! use pulseaudio; then
 		sed -i 's:=media-sound/pulseaudio\b:=media-sound/apulse:g' \
-			"${ED}"usr/share/${PN}/database.bash || die
+			"${ED}"/usr/share/${PN}/database.bash || die
 	fi
 }
 


### PR DESCRIPTION
${ED} no longer has a trailing slash in EAPI7 so the sed command in src_install always failed.