### PR TITLE
games-util/esteam: Add This War of Mine

### DIFF
--- a/games-util/esteam/files/database.bash
+++ b/games-util/esteam/files/database.bash
@@ -160,6 +160,7 @@ LIBS[libnssutil3.so]=dev-libs/nss[@ABI@]
 LIBS[libnuma.so.1]=sys-process/numactl[@ABI@]
 LIBS[libogg.so.0]=media-libs/libogg[@ABI@]
 LIBS[libopenal.so.1]=media-libs/openal[@ABI@]
+LIBS[libOpenAL.so]=libopenal.so.1
 LIBS[libopenjpeg.so.5]=media-libs/openjpeg:0/5[@ABI@]
 LIBS[libopenvr_api.so]=+
 LIBS[libopus.so.0]=media-libs/opus[@ABI@]
@@ -335,6 +336,7 @@ UNBUNDLEABLES=(
 	"Sid Meier's Civilization V"
 	"Skullgirls"
 	"SpeedRunners"
+	"This War of Mine"
 	"Titan Attacks"
 	"Tomb Raider"
 	"Trine 2"


### PR DESCRIPTION
Only two libraries are used - libcurl and libOpenAl.so that needs symlink. Unbundled version works without any errors reported by steam.