### PR TITLE
sys-apps/sc-controller: Add 9999 version based on Ryochan7's Python 3 fork

### DIFF
--- a/sys-apps/sc-controller/sc-controller-9999.ebuild
+++ b/sys-apps/sc-controller/sc-controller-9999.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+EGIT_REPO_URI="https://github.com/Ryochan7/sc-controller.git"
+EGIT_BRANCH="python3"
+
+PYTHON_COMPAT=( python3_{6..8} )
+DISTUTILS_USE_SETUPTOOLS=no
+
+inherit distutils-r1 linux-info git-r3 xdg-utils
+
+DESCRIPTION="User-mode driver and GTK3 based GUI for Steam Controller"
+HOMEPAGE="https://github.com/Ryochan7/sc-controller/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS=""
+
+RDEPEND="${PYTHON_DEPS}
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/pylibacl[${PYTHON_USEDEP}]
+	gnome-base/librsvg:2[introspection]
+	>=x11-libs/gtk+-3.22:3"
+DEPEND="${RDEPEND}"
+
+CONFIG_CHECK="
+	~INPUT_UINPUT
+"
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}


### PR DESCRIPTION
Upstream for sc-controller has decided not to update from Python 2 to 3, instead rewriting in C.  Unfortunately, the dependency on Python 2 means that it's no longer possible to build the current code on Gentoo, even with the updated 0.4.5 ebuild in my overlay, since pylibacl no longer has PYTHON_TARGETS for Python 2.

The existing sc-controller is a fantastic program though and there are some [efforts underway](https://github.com/kozec/sc-controller/issues/498) to port the existing codebase to Python 3.  I've had success running Ryochan7's fork, so are we interested in having a more up-to-date ebuild here?