### PR TITLE
dev-libs/libappindicator: remove MULTILIB_USEDEP from 'virtual/pkgconfig'

### DIFF
--- a/dev-libs/libappindicator/libappindicator-12.10.0-r203.ebuild
+++ b/dev-libs/libappindicator/libappindicator-12.10.0-r203.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-util/glib-utils
-	virtual/pkgconfig[${MULTILIB_USEDEP}]
+	virtual/pkgconfig
 "
 
 PATCHES=(


### PR DESCRIPTION
`virtual/pkgconfig` doesn't have `abi_*` useflags anymore, so leaving `MULTILIB_USEDEP` causes portage to disable `abi_x86_32` on `libappindicator:2`.

[See this commit on Gentoo's repository.](https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-libs/libappindicator?id=5008bbcb72fc5e5889b0ab9f94aae16fc3698a57)