### PR TITLE
RFC/WIP steam-wrapper: add possiblity to run steam in another dir and/or another user

### DIFF
--- a/games-util/steam-launcher/files/steam-wrapper.sh
+++ b/games-util/steam-launcher/files/steam-wrapper.sh
@@ -1,32 +1,61 @@
 #!/bin/bash
 
-# Set a default STEAM_RUNTIME value.
-: ${STEAM_RUNTIME:=@@STEAM_RUNTIME@@}
-export STEAM_RUNTIME
-
-# Gentoo's lsb-release doesn't set this.
-export DISTRIB_RELEASE="@@PVR@@"
-
-# Find joystick devices to make Steam's old SDL library use them.
-IFS=$'\n'
-for f in $(find /dev/input -maxdepth 1 -type c | sort --version-sort); do
-	if udevadm info --query=property --name="$f" 2>/dev/null | grep --quiet ID_INPUT_JOYSTICK=1; then
-		export SDL_JOYSTICK_DEVICE+=${SDL_JOYSTICK_DEVICE+:}$f
-	fi
-done
-unset IFS
-
-# Add paths to occasionally needed libraries not found in /usr/lib.
-export LD_LIBRARY_PATH+="${LD_LIBRARY_PATH+:}@@GENTOO_LD_LIBRARY_PATH@@"
-
-# Steam appends /usr/lib32 to LD_LIBRARY_PATH. We need to make sure
-# that OpenGL implementation dir goes before that, so we need to
-# append it to user's LD_LIBRARY_PATH ourselves. But that's needed
-# only with the new eselect-opengl that uses 000opengl file.
-if [[ -f "/etc/env.d/000opengl" ]]; then
-	. "/etc/env.d/000opengl"
-	# Append only when LDPATH is non-empty -- i.e. using nvidia or ati.
-	[[ -n "${LDPATH}" ]] && LD_LIBRARY_PATH+=":${LDPATH}"
+if [[ -f "${HOME}/.steamrc" ]]; then
+	source ${HOME}/.steamrc
 fi
 
-. "${0%/*}"/../lib/steam/bin_steam.sh
+if [[ -z "${STEAM_USER}" ]]; then
+	# Set a default STEAM_RUNTIME value.
+	: ${STEAM_RUNTIME:=@@STEAM_RUNTIME@@}
+	export STEAM_RUNTIME
+
+	# Gentoo's lsb-release doesn't set this.
+	export DISTRIB_RELEASE="@@PVR@@"
+
+	# Find joystick devices to make Steam's old SDL library use them.
+	IFS=$'\n'
+	cd # fix find error if run with a different user
+	for f in $(find /dev/input -maxdepth 1 -type c | sort --version-sort); do
+		if udevadm info --query=property --name="$f" 2>/dev/null | grep --quiet ID_INPUT_JOYSTICK=1; then
+			export SDL_JOYSTICK_DEVICE+=${SDL_JOYSTICK_DEVICE+:}$f
+		fi
+	done
+	unset IFS
+
+	# Add paths to occasionally needed libraries not found in /usr/lib.
+	export LD_LIBRARY_PATH+="${LD_LIBRARY_PATH+:}@@GENTOO_LD_LIBRARY_PATH@@"
+
+	# Steam appends /usr/lib32 to LD_LIBRARY_PATH. We need to make sure
+	# that OpenGL implementation dir goes before that, so we need to
+	# append it to user's LD_LIBRARY_PATH ourselves. But that's needed
+	# only with the new eselect-opengl that uses 000opengl file.
+	if [[ -f "/etc/env.d/000opengl" ]]; then
+		. "/etc/env.d/000opengl"
+		# Append only when LDPATH is non-empty -- i.e. using nvidia or ati.
+		[[ -n "${LDPATH}" ]] && LD_LIBRARY_PATH+=":${LDPATH}"
+	fi
+
+	if [[ -n "${STEAM_HOME}" ]]; then
+		if [[ -w "${STEAM_HOME}" ]]; then
+			HOME="${STEAM_HOME}"
+			echo "running steam as user \"$(whoami)\", within \"${HOME}\""
+			. "${0%/*}"/../lib/steam/bin_steam.sh
+		else
+			echo "${STEAM_HOME} is not writeable for user \"$(whoami)\""
+			exit 1
+		fi
+	else
+		. "${0%/*}"/../lib/steam/bin_steam.sh
+	fi
+else
+	# check if required commands are available
+	[[ $(command -v /usr/bin/sudo) ]] || \
+		{ echo "You need \"app-admin/sudo\" installed to run steam as different user"; exit 1; }
+	[[ $(command -v /usr/bin/xhost) ]] || \
+		{ echo "You need \"x11-apps/xhost\" installed to run steam as different user"; exit 1; }
+
+	echo "executing steam as user \"${STEAM_USER}\""
+	/usr/bin/xhost si:localuser:${STEAM_USER}
+	/usr/bin/sudo STEAM_HOME=${STEAM_HOME} -u ${STEAM_USER} -- "${0}"
+	/usr/bin/xhost -si:localuser:${STEAM_USER}
+fi


### PR DESCRIPTION
Hi all,

For some time now i'm toying around with steam to be able to run it from a different directory instead from `HOME` and also tried to be able to run it with an different User. This is how far i got.

**Motivation:**
The reason why i want to run steam from another directory is basically because of the `SteamLinuxRuntime` feature. Using `SteamLinuxRuntime` for linux games allows to run games inside a container and, at least for me, made a few games running which didn't work before.
However, `SteamLinuxRuntime` also has it's own drawbacks, and one of them is that games which aren't installed in the default steam library directory (especially on a different disk) might not working. (see [1] - Common issues and workarounds)
Since i installed all games on a different disk, i wanted to make it possible to run steam from a different directory too. Gladly this is quite simple by simple starting `steam` with a different `HOME` variable.
Regarding starting `steam` from another user I think the reasoning is quite clear. The indention here was to make steam a bit more secure to use. My solution here is rather simple, but it works and i'm able to run steam from another user.

Both features can be used independently.

The changes are also quite simple and on an existing installation it would work like before. What i've added is that the script now looks out for ~/.steamrc and sources it if found. In this file i can set a `STEAM_USER` and `STEAM_HOME` variable.
`STEAM_HOME` would change the home directory from which steam should be started.
`STEAM_USER` would change the user from which steam should be started.

**Caveats:**
`STEAM_USER` introduces two more dependencies: `app-admin/sudo` and `x11-apps/xhost`. None of them are pulled right now but the script checks if these command are available. Personally i would put them behind a USE flag, so that users can decide if they want to be able to start `steam` with another user.
Also, in order to to be able to start a program with another user, sudo needs to be configured. I also read about problems with pulse-audio when starting steam from another user, but again there are simple workaround for these issues, for example [2].
For `STEAM_HOME` i didn't saw any drawbacks, but also haven't used it for a long time.

Comments and improvements are highly welcomed.
@chewi pinging you too since you made most changes recently on this script.

[1] https://github.com/ValveSoftware/steam-runtime/blob/master/doc/reporting-steamlinuxruntime-bugs.md
[2] https://dhole.github.io/post/pulseaudio_multiple_users/