### PR TITLE
Actually detect extra configured games libraries

### DIFF
--- a/games-util/esteam/files/script.bash
+++ b/games-util/esteam/files/script.bash
@@ -95,7 +95,7 @@ for HOME in $(getent passwd | cut -d: -f6 | sort -u); do
 		fi
 
 		IFS=$'\n'
-		for DIR in $(grep -hs $'^\t"[0-9][0-9]*"' "${DIR}"/[Ss]team[Aa]pps/libraryfolders.vdf | cut -d\" -f4); do
+		for DIR in $(grep -hs $'^\t\t"path"' "${DIR}"/[Ss]team[Aa]pps/libraryfolders.vdf | cut -d\" -f4); do
 			if [[ -d ${DIR}/steamapps/common || -d ${DIR}/SteamApps/common ]]; then
 				DIRS[${DIR}]=1
 			fi


### PR DESCRIPTION
Probably the format of the file has changed or something, this works for me with the latest version of Steam.