### PR TITLE
Add XCOM 2 to the unbundleable list

### DIFF
--- a/games-util/esteam/files/database.bash
+++ b/games-util/esteam/files/database.bash
@@ -345,6 +345,7 @@ UNBUNDLEABLES=(
 	"Trine 2"
 	"Unrailed"
 	"WormsWMD"
+	"XCOM 2"
 )
 
 # The following lack unbundleable libraries:


### PR DESCRIPTION
It only uses libcurl.so.4 and seems to work fine with the system libraries. It
doesn't start with the bundled library because of old libidn and librtmp.