### PR TITLE
games-util/steam-launcher: clarify INPUT_UINPUT warning message

### DIFF
--- a/games-util/steam-launcher/steam-launcher-1.0.0.74-r1.ebuild
+++ b/games-util/steam-launcher/steam-launcher-1.0.0.74-r1.ebuild
@@ -56,8 +56,9 @@ pkg_setup() {
 	linux-info_pkg_setup
 
 	if ! { linux_config_exists && linux_chkconfig_present INPUT_UINPUT; }; then
-		ewarn "If you want to use the Steam controller, please make sure"
-		ewarn "CONFIG_INPUT_UINPUT is enabled in your kernel config."
+		ewarn "If you want to use Steam Input's virtual controller"
+		eawen "implementation, please make sure CONFIG_INPUT_UINPUT"
+		ewarn "is enabled in your kernel config."
 
 		# Device Drivers
 		#  -> Input device support


### PR DESCRIPTION
This fixes https://github.com/anyc/steam-overlay/issues/269

With proton-4.11 onwards, this config option is required for all
non-xbox controllers. Just like on native windows, steam/proton
emulates a xbox controller for connected controllers. This fails
if this config option is not enabled.

Closes: https://github.com/anyc/steam-overlay/issues/269
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>