### PR TITLE
Fixes steam-wrapper.sh for libcxx LLVM Profile Segfaults

### DIFF
--- a/games-util/steam-launcher/files/steam-wrapper.sh
+++ b/games-util/steam-launcher/files/steam-wrapper.sh
@@ -11,15 +11,17 @@ export DISTRIB_RELEASE="@@PVR@@"
 export LD_LIBRARY_PATH+="${LD_LIBRARY_PATH+:}@@GENTOO_LD_LIBRARY_PATH@@"
 
 # Preload the extest library when running in wayland session
-if [[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" &&
-		${XDG_SESSION_TYPE} == wayland ]]; then
-	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
-elif [ -f `find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"` ] &&
-		[ "$(eselect profile list | grep '\*' | grep clang)" != "" ] && [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+if [ -f `find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"` ] &&
+		[ "$(eselect profile list | grep '\*' | grep clang)" != "" ] &&
+  		[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" ] &&
+  		[ "$XDG_SESSION_TYPE" = "wayland" ]; then
 	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
 	# Fixes Steam not properly launching on LLVM+Wayland systems
 	# Backticks (``) are being used because it captures spaces inside paths; not that there should be. Shellcheck will complain about this.
 	export LD_PRELOAD+="${LD_PRELOAD+:}`find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"`"
+elif [[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" &&
+		${XDG_SESSION_TYPE} == wayland ]]; then
+	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
 fi
 
 # Steam renames LD_LIBRARY_PATH to SYSTEM_LD_LIBRARY_PATH and it then becomes

--- a/games-util/steam-launcher/files/steam-wrapper.sh
+++ b/games-util/steam-launcher/files/steam-wrapper.sh
@@ -10,16 +10,15 @@ export DISTRIB_RELEASE="@@PVR@@"
 # Add paths to occasionally needed libraries not found in /usr/lib.
 export LD_LIBRARY_PATH+="${LD_LIBRARY_PATH+:}@@GENTOO_LD_LIBRARY_PATH@@"
 
-# Preload the extest library when running in wayland session
-if [ -f `find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"` ] &&
-		[ "$(eselect profile list | grep '\*' | grep clang)" != "" ] &&
-  		[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" ] &&
-  		[ "$XDG_SESSION_TYPE" = "wayland" ]; then
-	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
+
+if [ "$(eselect profile list | grep '\*' | grep clang)" != "" ] || [ "$(eselect profile list | grep '\*' | grep llvm)" != "" ]; then
 	# Fixes Steam not properly launching on LLVM+Wayland systems
 	# Backticks (``) are being used because it captures spaces inside paths; not that there should be. Shellcheck will complain about this.
-	export LD_PRELOAD+="${LD_PRELOAD+:}`find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"`"
-elif [[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" &&
+	export LD_PRELOAD+="${LD_PRELOAD+:}`find /usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32 -type l -name 'libstdc++.so'`"
+fi
+
+# Preload the extest library when running in wayland session
+if [[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" &&
 		${XDG_SESSION_TYPE} == wayland ]]; then
 	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
 fi

--- a/games-util/steam-launcher/files/steam-wrapper.sh
+++ b/games-util/steam-launcher/files/steam-wrapper.sh
@@ -14,6 +14,12 @@ export LD_LIBRARY_PATH+="${LD_LIBRARY_PATH+:}@@GENTOO_LD_LIBRARY_PATH@@"
 if [[ -f "@@GENTOO_X86_LIBDIR@@/libextest.so" &&
 		${XDG_SESSION_TYPE} == wayland ]]; then
 	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
+elif [ -f `find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"` ] &&
+		[ "$(eselect profile list | grep '\*' | grep clang)" != "" ] && [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+	export LD_PRELOAD+="${LD_PRELOAD+:}@@GENTOO_X86_LIBDIR@@/libextest.so"
+	# Fixes Steam not properly launching on LLVM+Wayland systems
+	# Backticks (``) are being used because it captures spaces inside paths; not that there should be. Shellcheck will complain about this.
+	export LD_PRELOAD+="${LD_PRELOAD+:}`find "/usr/lib/gcc/x86_64-pc-linux-gnu/$(gcc --version | grep gcc | sed -E 's|[A-Za-z]+\s+\([^)]*\)\s+||' | cut -f 1 -d '.')/32" -type l -name "libstdc++.so"`"
 fi
 
 # Steam renames LD_LIBRARY_PATH to SYSTEM_LD_LIBRARY_PATH and it then becomes


### PR DESCRIPTION
This commit checks if the current profile is set to Clang and, if running a Wayland session, detects the currently set GCC version and preloads libstdc++ [to fix LLVM profile segfaults for launching Steam.](https://wiki.gentoo.org/wiki/Steam/Client_troubleshooting#Segfault_when_using_libcxx) In my experience, this only seems to be required for Wayland sessions and not Xorg.