### PR TITLE
games-util/steam-launcher: Added missing dependency lsof

### DIFF
--- a/games-util/steam-launcher/steam-launcher-1.0.0.78-r1.ebuild
+++ b/games-util/steam-launcher/steam-launcher-1.0.0.78-r1.ebuild
@@ -22,6 +22,7 @@ RDEPEND="
 		app-arch/tar
 		app-shells/bash
 		net-misc/curl
+		sys-process/lsof
 
 		joystick? (
 			udev? ( games-util/game-device-udev-rules )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/917597