### PR TITLE
Fix grep command to include /dev/null

### DIFF
--- a/games-util/esteam/files/script.bash
+++ b/games-util/esteam/files/script.bash
@@ -99,7 +99,7 @@ for HOME in $(getent passwd | cut -d: -f6 | sort -u); do
 		fi
 
 		IFS=$'\n'
-		for DIR in $(grep -hs $'^\t\t"path"' "${DIR}"/[Ss]team[Aa]pps/libraryfolders.vdf | cut -d\" -f4); do
+		for DIR in $(grep -hs $'^\t\t"path"' "${DIR}"/[Ss]team[Aa]pps/libraryfolders.vdf /dev/null | cut -d\" -f4); do
 			if [[ -d ${DIR}/steamapps/common || -d ${DIR}/SteamApps/common ]]; then
 				DIRS[${DIR}]=1
 			fi


### PR DESCRIPTION
The glob pattern of "${DIR}"/[Ss]team[Aa]pps/libraryfolders.vdf was sometimes returning an empty string for me. This was causing grep to hang waiting for user input.

Adding /dev/null as an input file appears to fix the issue.